### PR TITLE
Upgrade slippi-js to version 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
-    "@slippi/slippi-js": "^5.1.1",
+    "@slippi/slippi-js": "^6.1.3",
     "lodash": "^4.17.20",
     "moment": "^2.29.1",
     "react": "^16.13.1",

--- a/src/containers/Options/index.tsx
+++ b/src/containers/Options/index.tsx
@@ -54,7 +54,7 @@ const Outer = styled.div`
   left: 0;
   width: 100%;
   background-color: black;
-  opacity: 0.2;
+  opacity: 0.5;
   z-index: 10;
   &.closed:hover {
     cursor: pointer;

--- a/src/lib/exists.ts
+++ b/src/lib/exists.ts
@@ -1,0 +1,7 @@
+// Based on https://github.com/wilsonzlin/edgesearch/blob/d03816dd4b18d3d2eb6d08cb1ae14f96f046141d/demo/wiki/client/src/util/util.ts
+
+// Ensures value is not null or undefined.
+// != does no type validation so we don't need to explcitly check for undefined.
+export function exists<T>(value: T | null | undefined): value is T {
+  return value != null;
+}

--- a/src/lib/readFile.ts
+++ b/src/lib/readFile.ts
@@ -21,12 +21,22 @@ function generateGameDetails(name: string, game: SlippiGame): GameDetails {
     throw new Error(`Invalid SLP file. Could not find game settings in file: ${name}`);
   }
 
+  const stats = game.getStats();
+  if (!stats) {
+    throw new Error(`Failed to process game stats for file: ${name}`);
+  }
+
+  const metadata = game.getMetadata();
+  if (!metadata) {
+    throw new Error(`Failed to load metadata for file: ${name}`);
+  }
+
   return {
     filePath: name,
     settings,
     frames: game.getFrames(),
-    stats: game.getStats(),
-    metadata: game.getMetadata(),
+    stats,
+    metadata,
     latestFrame: game.getLatestFrame(),
     gameEnd: game.getGameEnd(),
   };

--- a/src/lib/stats/definitions/firstBlood.ts
+++ b/src/lib/stats/definitions/firstBlood.ts
@@ -16,7 +16,7 @@ export const firstBlood: StatDefinition = {
       });
       const orderedDeathStocks = _.orderBy(deathStocks, ["endFrame"], ["asc"]);
       const firstStock = orderedDeathStocks[0];
-      if (!firstStock || firstStock.opponentIndex !== playerIndex) {
+      if (!firstStock || firstStock.playerIndex === playerIndex) {
         // console.log(`player ${playerIndex} did not draw first blood in game ${i + 1}`);
         return null;
       }

--- a/src/lib/stats/definitions/highestDamagePunish.ts
+++ b/src/lib/stats/definitions/highestDamagePunish.ts
@@ -1,0 +1,46 @@
+import { ConversionType } from "@slippi/slippi-js";
+import { exists } from "lib/exists";
+import _ from "lodash";
+
+import { StatDefinition } from "../types";
+
+export const highDamagePunishes: StatDefinition = {
+  name: "Highest Damage Punish",
+  type: "number",
+  betterDirection: "higher",
+  recommendedRounding: 1,
+  calculate(games, playerIndex) {
+    const punishes = _.flatMap(games, (game) => {
+      const conversions = _.get(game, ["stats", "conversions"]) || [];
+      return _.filter(conversions, (conversion) => {
+        const isForPlayer = conversion.playerIndex !== playerIndex;
+        const hasEndPercent = conversion.endPercent !== null;
+        return isForPlayer && hasEndPercent;
+      });
+    });
+
+    const getDamageDone = (punish: ConversionType) => {
+      if (exists(punish.endPercent)) {
+        return punish.endPercent - punish.startPercent;
+      }
+      return 0;
+    };
+
+    const orderedPunishes = _.orderBy(punishes, [getDamageDone], "desc");
+    const topPunish = _.first(orderedPunishes);
+    const simple = {
+      text: "N/A",
+      number: null as number | null,
+    };
+
+    if (topPunish) {
+      simple.number = getDamageDone(topPunish);
+      simple.text = simple.number.toFixed(this.recommendedRounding);
+    }
+
+    return {
+      result: _.take(orderedPunishes, 5),
+      simple: simple,
+    };
+  },
+};

--- a/src/lib/stats/definitions/index.js
+++ b/src/lib/stats/definitions/index.js
@@ -10,6 +10,7 @@ const _ = require("lodash");
 export * from "./firstBlood";
 export * from "./lCancelAccuracy";
 export * from "./neutralOpenerMoves";
+export * from "./killMoves";
 
 export const openingsPerKill = {
   name: "Openings / Kill",
@@ -38,50 +39,6 @@ export const neutralWins = {
   recommendedRounding: 0,
   calculate(games, playerIndex) {
     return genOverallRatioStat(games, playerIndex, "neutralWinRatio", this.recommendedRounding, "count");
-  },
-};
-
-export const killMoves = {
-  name: "Most Common Kill Move",
-  type: "text",
-  calculate(games, playerIndex) {
-    const killMoves = _.flatMap(games, (game) => {
-      const conversions = _.get(game, ["stats", "conversions"]) || [];
-      const conversionsForPlayer = _.filter(conversions, (conversion) => {
-        const isForPlayer = conversion.playerIndex === playerIndex;
-        const didKill = conversion.didKill;
-        return isForPlayer && didKill;
-      });
-
-      return _.map(conversionsForPlayer, (conversion) => {
-        return _.last(conversion.moves);
-      });
-    });
-
-    const killMovesByMove = _.groupBy(killMoves, "moveId");
-    const killMoveCounts = _.map(killMovesByMove, (moves) => {
-      const move = _.first(moves);
-      return {
-        count: moves.length,
-        id: move.moveId,
-        name: moveUtil.getMoveName(move.moveId),
-        shortName: moveUtil.getMoveShortName(move.moveId),
-      };
-    });
-
-    const orderedKillMoveCounts = _.orderBy(killMoveCounts, ["count"], ["desc"]);
-    const topKillMove = _.first(orderedKillMoveCounts);
-    let simpleText = "N/A";
-    if (topKillMove) {
-      simpleText = `${topKillMove.shortName} - ${topKillMove.count}`;
-    }
-
-    return {
-      result: orderedKillMoveCounts,
-      simple: {
-        text: simpleText.toUpperCase(),
-      },
-    };
   },
 };
 

--- a/src/lib/stats/definitions/index.js
+++ b/src/lib/stats/definitions/index.js
@@ -11,6 +11,7 @@ export * from "./lCancelAccuracy";
 export * from "./neutralOpenerMoves";
 export * from "./killMoves";
 export * from "./selfDestructs";
+export * from "./highestDamagePunish";
 
 export const openingsPerKill = {
   name: "Openings / Kill",
@@ -145,41 +146,6 @@ export const averageKillPercent = {
     return {
       result: result,
       simple: genSimpleFromRatio(result, this.recommendedRounding),
-    };
-  },
-};
-
-export const highDamagePunishes = {
-  name: "Highest Damage Punish",
-  type: "number",
-  betterDirection: "higher",
-  recommendedRounding: 1,
-  calculate(games, playerIndex) {
-    const punishes = _.flatMap(games, (game) => {
-      const conversions = _.get(game, ["stats", "conversions"]) || [];
-      return _.filter(conversions, (conversion) => {
-        const isForPlayer = conversion.playerIndex === playerIndex;
-        const hasEndPercent = conversion.endPercent !== null;
-        return isForPlayer && hasEndPercent;
-      });
-    });
-
-    const getDamageDone = (punish) => punish.endPercent - punish.startPercent;
-    const orderedPunishes = _.orderBy(punishes, [getDamageDone], "desc");
-    const topPunish = _.first(orderedPunishes);
-    const simple = {
-      text: "N/A",
-      number: null,
-    };
-
-    if (topPunish) {
-      simple.number = getDamageDone(topPunish);
-      simple.text = simple.number.toFixed(this.recommendedRounding);
-    }
-
-    return {
-      result: _.take(orderedPunishes, 5),
-      simple: simple,
     };
   },
 };

--- a/src/lib/stats/definitions/index.js
+++ b/src/lib/stats/definitions/index.js
@@ -4,13 +4,13 @@
  * Taken from: https://github.com/project-slippi/slippi-set-stats/blob/master/main.js
  */
 
-const { moves: moveUtil } = require("@slippi/slippi-js");
 const _ = require("lodash");
 
 export * from "./firstBlood";
 export * from "./lCancelAccuracy";
 export * from "./neutralOpenerMoves";
 export * from "./killMoves";
+export * from "./selfDestructs";
 
 export const openingsPerKill = {
   name: "Openings / Kill",
@@ -106,43 +106,6 @@ export const lateDeaths = {
     return {
       result: _.take(orderedPlayerStocks, 5),
       simple: simple,
-    };
-  },
-};
-
-export const selfDestructs = {
-  // Only show this one if greater than 2 for one player
-  name: "Total Self-Destructs",
-  type: "number",
-  betterDirection: "lower",
-  recommendedRounding: 0,
-  calculate(games, playerIndex) {
-    const sdCounts = _.map(games, (game) => {
-      const stocks = _.get(game, ["stats", "stocks"]) || [];
-      const playerEndedStocks = _.filter(stocks, (stock) => {
-        const isPlayer = stock.playerIndex === playerIndex;
-        const hasEndPercent = stock.endPercent !== null;
-        return isPlayer && hasEndPercent;
-      });
-
-      const conversions = _.get(game, ["stats", "conversions"]) || [];
-      const oppKillConversions = _.filter(conversions, (conversion) => {
-        const isOpp = conversion.playerIndex !== playerIndex;
-        const didKill = conversion.didKill;
-        return isOpp && didKill;
-      });
-
-      return playerEndedStocks.length - oppKillConversions.length;
-    });
-
-    const sdSum = _.sum(sdCounts);
-
-    return {
-      result: sdSum,
-      simple: {
-        number: sdSum,
-        text: `${sdSum}`,
-      },
     };
   },
 };

--- a/src/lib/stats/definitions/killMoves.ts
+++ b/src/lib/stats/definitions/killMoves.ts
@@ -1,0 +1,56 @@
+import { moves as moveUtil } from "@slippi/slippi-js";
+import _ from "lodash";
+
+import { StatDefinition } from "../types";
+
+export const killMoves: StatDefinition = {
+  name: "Most Common Kill Move",
+  type: "text",
+  calculate(games, playerIndex) {
+    const killMoves = _.flatMap(games, (game) => {
+      const conversions = _.get(game, ["stats", "conversions"]) || [];
+      const conversionsForPlayer = _.filter(conversions, (conversion) => {
+        const isForPlayer = conversion.lastHitBy === playerIndex;
+        const didKill = conversion.didKill;
+        return isForPlayer && didKill;
+      });
+
+      return conversionsForPlayer.map((conversion) => _.last(conversion.moves));
+    });
+
+    const killMovesByMove = _.groupBy(killMoves, "moveId");
+    const killMoveCounts = _.map(killMovesByMove, (moves) => {
+      const move = moves[0];
+      if (move) {
+        return {
+          count: moves.length,
+          id: move.moveId,
+          name: moveUtil.getMoveName(move.moveId),
+          shortName: moveUtil.getMoveShortName(move.moveId),
+        };
+      }
+
+      // Move is undefined so apparently this means it was a grab release??
+      return {
+        count: moves.length,
+        id: -1,
+        name: "Grab Release",
+        shortName: "grab release",
+      };
+    });
+
+    const orderedKillMoveCounts = _.orderBy(killMoveCounts, ["count"], ["desc"]);
+    const topKillMove = _.first(orderedKillMoveCounts);
+    let simpleText = "N/A";
+    if (topKillMove) {
+      simpleText = `${topKillMove.shortName} - ${topKillMove.count}`;
+    }
+
+    return {
+      result: orderedKillMoveCounts,
+      simple: {
+        text: simpleText.toUpperCase(),
+      },
+    };
+  },
+};

--- a/src/lib/stats/definitions/lCancelAccuracy.ts
+++ b/src/lib/stats/definitions/lCancelAccuracy.ts
@@ -1,91 +1,4 @@
-import { FramesType } from "@slippi/slippi-js";
-
 import { StatDefinition } from "../types";
-
-/**
- * Based on pdiot's L Cancel calculation code from here:
- *
- * https://github.com/pdiot/Slippi-Electron/blob/354f1dd73092cf844df76501936c3dceb4165328/slippi-stats-workerfile.js
- */
-
-function getLCancels(frames: FramesType, playerIndex: number) {
-  const playerLCancels = { successful: 0, failed: 0 };
-  const playerFailedMoves = [];
-  for (const frameNumber of Object.keys(frames)) {
-    const frameKey = +frameNumber;
-    const playerPostFrameUpdate = (frames[frameKey].players as any[]).find(
-      (player) => player.pre.playerIndex === playerIndex
-    ).post;
-    const playerAttack = getAttackAction(playerPostFrameUpdate.actionStateId);
-
-    if (playerAttack) {
-      if (playerPostFrameUpdate.lCancelStatus === 1) {
-        playerLCancels.successful++;
-      } else if (playerPostFrameUpdate.lCancelStatus === 2) {
-        playerLCancels.failed++;
-        playerFailedMoves.push(playerAttack);
-      }
-    }
-  }
-  const ratio = playerLCancels.successful / (playerLCancels.successful + playerLCancels.failed);
-  const returnValue = {
-    ...playerLCancels,
-    ratio,
-  };
-  return returnValue;
-}
-
-const ATTACK_ACTION_STATES = new Map<
-  number,
-  {
-    id: number;
-    name: string;
-    niceName: string;
-  }
->();
-
-ATTACK_ACTION_STATES.set(44, { id: 44, name: "Attack11", niceName: "Jab 1" });
-ATTACK_ACTION_STATES.set(45, { id: 45, name: "Attack12", niceName: "Jab 2" });
-ATTACK_ACTION_STATES.set(46, { id: 46, name: "Attack13", niceName: "Jab 3" });
-ATTACK_ACTION_STATES.set(47, { id: 47, name: "Attack100Start", niceName: "Rapid jab" });
-ATTACK_ACTION_STATES.set(48, { id: 48, name: "Attack100Loop", niceName: "Rapid jab" });
-ATTACK_ACTION_STATES.set(49, { id: 49, name: "Attack100End", niceName: "Rapid jab" });
-ATTACK_ACTION_STATES.set(50, { id: 50, name: "AttackDash", niceName: "Dash attack" });
-ATTACK_ACTION_STATES.set(51, { id: 51, name: "AttackS3Hi", niceName: "Forward tilt" });
-ATTACK_ACTION_STATES.set(52, { id: 52, name: "AttackS3HiS", niceName: "Forward tilt" });
-ATTACK_ACTION_STATES.set(53, { id: 53, name: "AttackS3S", niceName: "Forward tilt" });
-ATTACK_ACTION_STATES.set(54, { id: 54, name: "AttackS3LwS", niceName: "Forward tilt" });
-ATTACK_ACTION_STATES.set(55, { id: 55, name: "AttackS3Lw", niceName: "Forward tilt" });
-ATTACK_ACTION_STATES.set(56, { id: 56, name: "AttackHi3", niceName: "Up tilt" });
-ATTACK_ACTION_STATES.set(57, { id: 57, name: "AttackLw3", niceName: "Down tilt" });
-ATTACK_ACTION_STATES.set(58, { id: 58, name: "AttackS4Hi", niceName: "Forward smash" });
-ATTACK_ACTION_STATES.set(59, { id: 59, name: "AttackS4HiS", niceName: "Forward smash" });
-ATTACK_ACTION_STATES.set(60, { id: 60, name: "AttackS4S", niceName: "Forward smash" });
-ATTACK_ACTION_STATES.set(61, { id: 61, name: "AttackS4LwS", niceName: "Forward smash" });
-ATTACK_ACTION_STATES.set(62, { id: 62, name: "AttackS4Lw", niceName: "Forward smash" });
-ATTACK_ACTION_STATES.set(63, { id: 63, name: "AttackHi4", niceName: "Up smash" });
-ATTACK_ACTION_STATES.set(64, { id: 64, name: "AttackLw4", niceName: "Down smash" });
-ATTACK_ACTION_STATES.set(65, { id: 65, name: "AttackAirN", niceName: "Neutral air" });
-ATTACK_ACTION_STATES.set(66, { id: 66, name: "AttackAirF", niceName: "Forward air" });
-ATTACK_ACTION_STATES.set(67, { id: 67, name: "AttackAirB", niceName: "Back air" });
-ATTACK_ACTION_STATES.set(68, { id: 68, name: "AttackAirHi", niceName: "Up air" });
-ATTACK_ACTION_STATES.set(69, { id: 69, name: "AttackAirLw", niceName: "Down air" });
-ATTACK_ACTION_STATES.set(70, { id: 70, name: "LandingAirN", niceName: "Nair landing" });
-ATTACK_ACTION_STATES.set(71, { id: 71, name: "LandingAirF", niceName: "Fair landing" });
-ATTACK_ACTION_STATES.set(72, { id: 72, name: "LandingAirB", niceName: "Bair landing" });
-ATTACK_ACTION_STATES.set(73, { id: 73, name: "LandingAirHi", niceName: "Uair landing" });
-ATTACK_ACTION_STATES.set(74, { id: 74, name: "LandingAirLw", niceName: "Dair landing" });
-ATTACK_ACTION_STATES.set(212, { id: 212, name: "Catch", niceName: "Grab" });
-ATTACK_ACTION_STATES.set(214, { id: 214, name: "CatchDash", niceName: "Dash grab" });
-
-function getAttackAction(id: number) {
-  const action = ATTACK_ACTION_STATES.get(id);
-  if (action) {
-    return action.niceName;
-  } else {
-    return null;
-  }
-}
 
 export const lCancelAccuracy: StatDefinition = {
   name: "L-Cancel Accuracy",
@@ -94,19 +7,25 @@ export const lCancelAccuracy: StatDefinition = {
   recommendedRounding: 0,
   calculate(games, playerIndex) {
     const lCancelsPerGame = games.map((game) => {
-      const frames = game.frames;
-      const gameLCancels = getLCancels(frames, playerIndex);
-      return gameLCancels;
+      const actionCounts = game.stats.actionCounts.find((counts) => counts.playerIndex === playerIndex);
+      if (!actionCounts) {
+        return {
+          success: 0,
+          fail: 0,
+        };
+      }
+
+      return actionCounts.lCancelCount;
     });
 
     const totalLCancels = lCancelsPerGame.reduce(
       (tally, val) => ({
-        successful: tally.successful + val.successful,
-        failed: tally.failed + val.failed,
+        success: tally.success + val.success,
+        fail: tally.fail + val.fail,
       }),
-      { successful: 0, failed: 0 }
+      { success: 0, fail: 0 }
     );
-    const ratio = totalLCancels.successful / (totalLCancels.successful + totalLCancels.failed);
+    const ratio = totalLCancels.success / (totalLCancels.success + totalLCancels.fail);
 
     return {
       result: totalLCancels,

--- a/src/lib/stats/definitions/neutralOpenerMoves.ts
+++ b/src/lib/stats/definitions/neutralOpenerMoves.ts
@@ -10,7 +10,7 @@ export const neutralOpenerMoves: StatDefinition = {
     const neutralMoves = _.flatMap(games, (game) => {
       const conversions = _.get(game, ["stats", "conversions"]) ?? [];
       const conversionsForPlayer = _.filter(conversions, (conversion) => {
-        const isForPlayer = conversion.playerIndex === playerIndex;
+        const isForPlayer = conversion.lastHitBy === playerIndex;
         const isNeutralWin = conversion.openingType === "neutral-win";
         return isForPlayer && isNeutralWin;
       });

--- a/src/lib/stats/definitions/selfDestructs.ts
+++ b/src/lib/stats/definitions/selfDestructs.ts
@@ -1,0 +1,40 @@
+import _ from "lodash";
+
+import { StatDefinition } from "../types";
+
+export const selfDestructs: StatDefinition = {
+  // Only show this one if greater than 2 for one player
+  name: "Total Self-Destructs",
+  type: "number",
+  betterDirection: "lower",
+  recommendedRounding: 0,
+  calculate(games, playerIndex) {
+    const sdCounts = _.map(games, (game) => {
+      const stocks = _.get(game, ["stats", "stocks"]) || [];
+      const playerEndedStocks = _.filter(stocks, (stock) => {
+        const isPlayer = stock.playerIndex === playerIndex;
+        const hasEndPercent = stock.endPercent !== null;
+        return isPlayer && hasEndPercent;
+      });
+
+      const conversions = _.get(game, ["stats", "conversions"]) || [];
+      const oppKillConversions = _.filter(conversions, (conversion) => {
+        const isOpp = conversion.playerIndex === playerIndex;
+        const didKill = conversion.didKill;
+        return isOpp && didKill;
+      });
+
+      return playerEndedStocks.length - oppKillConversions.length;
+    });
+
+    const sdSum = _.sum(sdCounts);
+
+    return {
+      result: sdSum,
+      simple: {
+        number: sdSum,
+        text: `${sdSum}`,
+      },
+    };
+  },
+};

--- a/src/views/RenderView.tsx
+++ b/src/views/RenderView.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { css, jsx } from "@emotion/core";
+import { css, Global, jsx } from "@emotion/core";
 import styled from "@emotion/styled";
 import { ExternalLink as A } from "components/ExternalLink";
 import { Header } from "components/Header";
@@ -16,15 +16,6 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  &:hover {
-    .settings {
-      opacity: 1;
-    }
-  }
-  .settings {
-    opacity: 0;
-    transition: opacity 0.2s ease-in-out;
-  }
 `;
 
 export interface RenderViewProps {
@@ -67,10 +58,29 @@ export const RenderView: React.FC<RenderViewProps> = ({ showSlippiLogo }) => {
           </A>
         </div>
         <RenderDisplay primaryColor={primaryColor} secondaryColor={secondaryColor} />
-        <div className="settings">
-          <Options />
-        </div>
+        <Settings />
       </Container>
     </div>
+  );
+};
+
+const Settings: React.FC = () => {
+  return (
+    <React.Fragment>
+      <Global
+        styles={css`
+          body:hover .settings {
+            opacity: 1;
+          }
+          .settings {
+            opacity: 0;
+            transition: opacity 0.2s ease-in-out;
+          }
+        `}
+      />
+      <div className="settings">
+        <Options />
+      </div>
+    </React.Fragment>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1422,10 +1422,10 @@
   resolved "https://registry.yarnpkg.com/@shelacek/ubjson/-/ubjson-1.0.1.tgz#009d39ea22fa80e036f97e936650951a8225fafe"
   integrity sha512-0vlllP3M7fUElSd4239wmnv6SqDeymJgjRkb/iusOyDN4I0xjc8hrX4Zk/KYoAesgSdsnnSwhOU7g+IewmdaAw==
 
-"@slippi/slippi-js@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@slippi/slippi-js/-/slippi-js-5.1.1.tgz#63dc0ba131019fcaf9fe01417c6ecbe53db095aa"
-  integrity sha512-5iutrhwfjQNA2Ri9vzWM30wsAY43MVzSWT/hW/CkqS3jEU/I8PIpn5kMVLz2gESYnYOjOSTCB4sqEQJBLrBBSA==
+"@slippi/slippi-js@^6.1.3":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@slippi/slippi-js/-/slippi-js-6.1.3.tgz#212b4531f76cabd3d6e6f259c4222ec8e47b1561"
+  integrity sha512-BevtDEzS1Gu6ShIU/lGsncpvWfhoI7+dnLfUaRi3T7LLIUASsUxKISqKnlWCbnAvG+bWL0CSGuQicPdRmtji9w==
   dependencies:
     "@shelacek/ubjson" "^1.0.1"
     enet "^0.2.9"


### PR DESCRIPTION
This PR changes the following:
* updates the slippi-js dependency to version 6.
* fixes the bug where hover handling didn't work very well on high resolution screens.

Version 6 of slippi-js has a breaking change where the conversions are not owned by the player performing the combo/attack but are now owned by the player being combo'd. Additionally, since there is no longer the concept of `opponentIndex` parts of the code need to be updated to correctly identify the correct player.
